### PR TITLE
Update schema and add indexes

### DIFF
--- a/drizzle/0000_peaceful_molten_man.sql
+++ b/drizzle/0000_peaceful_molten_man.sql
@@ -1,0 +1,18 @@
+CREATE TABLE IF NOT EXISTS "advocates" (
+	"id" serial PRIMARY KEY NOT NULL,
+	"first_name" varchar(100) NOT NULL,
+	"last_name" varchar(100) NOT NULL,
+	"city" varchar(100) NOT NULL,
+	"degree" varchar(200) NOT NULL,
+	"specialties" jsonb DEFAULT '[]'::jsonb NOT NULL,
+	"years_of_experience" integer NOT NULL,
+	"phone_number" varchar(20) NOT NULL,
+	"email" varchar(255) NOT NULL,
+	"created_at" timestamp DEFAULT CURRENT_TIMESTAMP,
+	"updated_at" timestamp DEFAULT CURRENT_TIMESTAMP,
+	CONSTRAINT "advocates_email_unique" UNIQUE("email")
+);
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "name_idx" ON "advocates" USING btree ("first_name","last_name");--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "city_idx" ON "advocates" USING btree ("city");--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "name_search_idx" ON "advocates" USING btree (to_tsvector('english', first_name || ' ' || last_name));

--- a/drizzle/meta/0000_snapshot.json
+++ b/drizzle/meta/0000_snapshot.json
@@ -1,0 +1,155 @@
+{
+  "id": "18e7718f-535b-40c8-b2c1-e4065629842f",
+  "prevId": "00000000-0000-0000-0000-000000000000",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.advocates": {
+      "name": "advocates",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "first_name": {
+          "name": "first_name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_name": {
+          "name": "last_name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "city": {
+          "name": "city",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "degree": {
+          "name": "degree",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "specialties": {
+          "name": "specialties",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "years_of_experience": {
+          "name": "years_of_experience",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "phone_number": {
+          "name": "phone_number",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "name_idx": {
+          "name": "name_idx",
+          "columns": [
+            {
+              "expression": "first_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "last_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "city_idx": {
+          "name": "city_idx",
+          "columns": [
+            {
+              "expression": "city",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "name_search_idx": {
+          "name": "name_search_idx",
+          "columns": [
+            {
+              "expression": "to_tsvector('english', first_name || ' ' || last_name)",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "advocates_email_unique": {
+          "name": "advocates_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      }
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -1,0 +1,13 @@
+{
+  "version": "7",
+  "dialect": "postgresql",
+  "entries": [
+    {
+      "idx": 0,
+      "version": "7",
+      "when": 1738962672420,
+      "tag": "0000_peaceful_molten_man",
+      "breakpoints": true
+    }
+  ]
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@types/lodash": "^4.17.15",
         "axios": "^1.7.9",
+        "dotenv": "^16.4.7",
         "drizzle-orm": "^0.32.1",
         "lodash": "^4.17.21",
         "next": "^14.2.19",
@@ -2135,6 +2136,17 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "16.4.7",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.4.7.tgz",
+      "integrity": "sha512-47qPchRCykZC03FhkYAhrvwU4xDBFIj1QPqaarj6mdM/hgUzfPHcpkHJOn3mJAufFeeAxAzeGsr5X0M4k6fLZQ==",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
       }
     },
     "node_modules/drizzle-kit": {

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   "dependencies": {
     "@types/lodash": "^4.17.15",
     "axios": "^1.7.9",
+    "dotenv": "^16.4.7",
     "drizzle-orm": "^0.32.1",
     "lodash": "^4.17.21",
     "next": "^14.2.19",

--- a/src/app/api/advocates/route.ts
+++ b/src/app/api/advocates/route.ts
@@ -5,7 +5,7 @@ import { advocates } from "../../../db/schema";
 export async function GET(request: Request) {
   const { searchParams } = new URL(request.url);
   const page = parseInt(searchParams.get('page') || '1');
-  const limit = 20;
+  const limit = 5;
   const offset = (page - 1) * limit;
   const search = searchParams.get('search') || '';
 

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -2,23 +2,34 @@ import { sql } from "drizzle-orm";
 import {
   pgTable,
   integer,
-  text,
   jsonb,
   serial,
   timestamp,
-  bigint,
+  varchar,
+  index,
 } from "drizzle-orm/pg-core";
 
-const advocates = pgTable("advocates", {
-  id: serial("id").primaryKey(),
-  firstName: text("first_name").notNull(),
-  lastName: text("last_name").notNull(),
-  city: text("city").notNull(),
-  degree: text("degree").notNull(),
-  specialties: jsonb("payload").default([]).notNull(),
-  yearsOfExperience: integer("years_of_experience").notNull(),
-  phoneNumber: bigint("phone_number", { mode: "number" }).notNull(),
-  createdAt: timestamp("created_at").default(sql`CURRENT_TIMESTAMP`),
-});
+const advocates = pgTable(
+  "advocates",
+  {
+    id: serial("id").primaryKey(),
+    firstName: varchar("first_name", { length: 100 }).notNull(),
+    lastName: varchar("last_name", { length: 100 }).notNull(),
+    city: varchar("city", { length: 100 }).notNull(),
+    degree: varchar("degree", { length: 200 }).notNull(),
+    specialties: jsonb("specialties").default([]).notNull(),
+    yearsOfExperience: integer("years_of_experience").notNull(),
+    phoneNumber: varchar("phone_number", { length: 20 }).notNull(),
+    createdAt: timestamp("created_at").default(sql`CURRENT_TIMESTAMP`),
+    updatedAt: timestamp("updated_at").default(sql`CURRENT_TIMESTAMP`),
+  },
+  (table) => ({
+    nameIdx: index("name_idx").on(table.firstName, table.lastName),
+    cityIdx: index("city_idx").on(table.city),
+    nameSearchIdx: index("name_search_idx").on(
+      sql`to_tsvector('english', first_name || ' ' || last_name)`
+    ),
+  })
+);
 
 export { advocates };


### PR DESCRIPTION
This PR updates the schema in the following ways:

- Adds indexes on first name, last name and city for faster searching results
- Changes column name from "payload" to "specialties"
- Changes phone number to string instead of bigint because phone numbers can sometimes contain none numeric values

This PR adds dotenv dependency and handles migrations in a more robust way